### PR TITLE
添加私聊消息写入 SQLite 数据库功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*/__pycache__/
+__pycache__/
+output/

--- a/db/models.py
+++ b/db/models.py
@@ -8,6 +8,7 @@ from .man import DatabaseManager
 
 import element_pb2
 import elements
+import json
 
 Base = declarative_base()
 
@@ -116,7 +117,7 @@ class C2cMessage(Base,Message):
     def direction(self):
         if self.sender_flag == 0:
             return "收"
-        elif self.sender_flag == 1 or 2:
+        elif self.sender_flag == 1 or self.sender_flag == 2:  # ?
             return "发"
         elif self.sender_flag == 5:
             return "转发"
@@ -132,6 +133,30 @@ class C2cMessage(Base,Message):
                 f.write(f"{content[0]}\n{content[1]}\n")
 
             f.write("\n")
+
+    def write_db(self):
+        """return formatted data but not write to db."""
+        msg_contents = []
+        msg_types = set()
+        for content in self.contents:
+            section = {"type": content[0], "content": content[1]}
+            msg_contents.append(section)
+            msg_types.add(content[0])
+        msg_types = filter(lambda x: x is not None, msg_types)
+        msg_contents_json = json.dumps(msg_contents)
+
+        direction_num = self.sender_flag
+
+        return (
+            self.time,
+            self.readable_time,
+            self.sender_num,
+            self.interlocutor_num,
+            "|".join(msg_types),
+            msg_contents_json,
+            self.direction.strip(),
+            direction_num,
+        )
 
 
 @DatabaseManager.register_model("nt_msg")

--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ def run_single(get_message, task_type, path, write_db: bool = False):
         logging.info("已启用写入数据库，正在初始化数据库")
 
         # preprocess messages
-        for message in message.all():
+        for message in messages.all():
             message.parse()
             if message.interlocutor_num not in db_connections.keys():
                 db_conn, cursor = init_db(
@@ -86,7 +86,6 @@ def run_single(get_message, task_type, path, write_db: bool = False):
             )
             db_conn.commit()
             db_conn.close()
-            cursor.close()
 
     logging.info(f"成功解析并写入{task_type}消息")
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import Path
 from sys import argv
 
+import sqlite3
 from tqdm import tqdm
 
 import db
@@ -17,6 +18,8 @@ def output_path(db_path):
     c2c_path = db_path / ".." / "output" / "c2c"
     group_path = db_path / ".." / "output" / "group"
 
+    # c2c_path = Path(".") / "output" / "c2c"
+    # group_path = Path(".") / "output" / "group"
     if not c2c_path.exists():
         c2c_path.mkdir(parents=True)
     if not group_path.exists():
@@ -24,8 +27,28 @@ def output_path(db_path):
 
     return c2c_path, group_path
 
+def init_db(db_path: Path | str):
+    db_conn = sqlite3.connect(db_path)
+    db_conn.execute("PRAGMA journal_mode=WAL;")
+    cursor = db_conn.cursor()
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            time_stamp INTEGER,
+            time TEXT,
+            sender_qq TEXT,
+            interlocutor_qq TEXT,
+            types TEXT,
+            contents JSON,
+            direction_str TEXT CHECK(direction_str IN ('收', '发', '转发', '未知')),
+            direction INTEGER 
+            );
+    """)
 
-def run_single(get_message, task_type, path):
+    return db_conn, cursor
+
+
+def run_single(get_message, task_type, path, write_db: bool = False):
     logging.info(f"开始读取{task_type}消息")
     messages = get_message()
     logging.info(f"成功读取{messages.count()}条{task_type}消息")
@@ -34,17 +57,48 @@ def run_single(get_message, task_type, path):
     for message in tqdm(messages.all()):
         message.parse()
         message.write(path)
+
+    if write_db:
+        # ONLY SUPPORT -> c2c messages <-
+        db_connections = {}
+        msgs = {}
+        logging.info("已启用写入数据库，正在初始化数据库")
+
+        # preprocess messages
+        for message in message.all():
+            message.parse()
+            if message.interlocutor_num not in db_connections.keys():
+                db_conn, cursor = init_db(
+                    path
+                    / f"{message.mapping.qq_num if message.mapping else message.interlocutor_num}.db"
+                )
+                db_connections[message.interlocutor_num] = db_conn, cursor
+                msgs[message.interlocutor_num] = []
+
+            msgs[message.interlocutor_num].append(message.write_db())
+
+        # write to db
+        for interlocutor_num in tqdm(msgs.keys()):
+            db_conn, cursor = db_connections[interlocutor_num]
+            cursor.executemany(
+                "INSERT INTO messages (time_stamp, time, sender_qq, interlocutor_qq, types, contents, direction_str, direction) VALUES (?, ?, ?, ?, ?, ?, ?, ?);",
+                msgs[interlocutor_num],
+            )
+            db_conn.commit()
+            db_conn.close()
+            cursor.close()
+
     logging.info(f"成功解析并写入{task_type}消息")
 
-def main():
+def main(write_db: bool = False):
 
     db_path = Path(argv[1])
     c2c_path, group_path = output_path(db_path)
 
     dbman = db.DatabaseManager(db_path)
 
-    run_single(dbman.c2c_messages, "私聊", c2c_path)
+    run_single(dbman.c2c_messages, "私聊", c2c_path, write_db)
     run_single(dbman.group_messages, "群聊", group_path)
 
 if __name__ == '__main__':
-    main()
+    main(True)


### PR DESCRIPTION
- 添加了`.gitignore`排除掉`__pycache__`之类的
- 修改了C2cMessage.direction方法因为看起来逻辑是 senderflag = 1或2 为发送,但是此处代码写的是**一定**会进到发送这个分支里的
- 修改了 `models.py` 的 `C2cMessage` 以支持私聊消息写入独立的数据库, 相比纯文本更方便后续对聊天记录进行操作
通过在主函数调用传入`write_db`参数控制是否启用数据库写入
写入的消息数据类似下图
![image](https://github.com/user-attachments/assets/2ab2a6e2-dd94-456e-868a-eed808f30c4c)
